### PR TITLE
Fix the deprecation warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/xxhash.ex
+++ b/lib/xxhash.ex
@@ -18,7 +18,7 @@ defmodule XXHash do
     def mul(a, b), do: (a * b) |> mask
     def lshift(a, b), do: a <<< b |> mask
     def rshift(a, b), do: a >>> b
-    def xor(a, b), do: (a ^^^ b) |> mask
+    def xor(a, b), do: Bitwise.bxor(a, b) |> mask
     def rotl(a, b), do: lshift(a, b) ||| rshift(a, 32 - b)
     def rshift_xor(a, b), do: a |> xor(rshift(a, b))
     def read(<<a::32>>) when <<1::32-little>> != <<1::32-native>>, do: a
@@ -43,7 +43,7 @@ defmodule XXHash do
     def mul(a, b), do: (a * b) |> mask
     def lshift(a, b), do: a <<< b |> mask
     def rshift(a, b), do: a >>> b
-    def xor(a, b), do: (a ^^^ b) |> mask
+    def xor(a, b), do: Bitwise.bxor(a, b) |> mask
     def rotl(a, b), do: lshift(a, b) ||| rshift(a, 64 - b)
     def rshift_xor(a, b), do: a |> xor(rshift(a, b))
     def read(<<a::64>>) when <<1::64-little>> != <<1::64-native>>, do: a


### PR DESCRIPTION
Fixed the deprecation warnings by following the recommandations.

```
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:3

Compiling 1 file (.ex)
warning: ^^^ is deprecated. It is typically used as xor but it has the wrong precedence, use Bitwise.bxor/2 instead
  lib/xxhash.ex:21:27

warning: ^^^ is deprecated. It is typically used as xor but it has the wrong precedence, use Bitwise.bxor/2 instead
  lib/xxhash.ex:46:27
```

The tests pass